### PR TITLE
Updated dependencies for 4.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,11 +25,11 @@
   },
   "homepage": "https://github.com/dudleycarr/snappystream",
   "dependencies": {
+    "async": "^1.4.2",
     "coffee-script": "^1.7.1",
-    "sse4_crc32": "git+https://github.com/dudleycarr/sse4_crc32",
-    "snappy": "git+https://github.com/dudleycarr/node-snappy",
     "int24": "0.0.1",
-    "async": "^1.4.2"
+    "snappy": "^4.0.3",
+    "sse4_crc32": "^4.1.1"
   },
   "devDependencies": {
     "mocha": "^1.19.0",


### PR DESCRIPTION
Hey there,

After fighting with a bunch of mismatch and binding missing errors when trying to upgrade my application to Node 4.2.1 (LTS), I updated the deps on snappystream and everything seems to work. 

Weirdly enough, was working fine locally on my mac, just not on CI or AWS (both linux).

Both `snappy` and `sse4_crc32` have been updated since you patched them for Node 4 a couple of months ago.

Thanks!